### PR TITLE
désinscription depuis la modification de compte

### DIFF
--- a/EventListeners/NewsletterListener.php
+++ b/EventListeners/NewsletterListener.php
@@ -104,7 +104,7 @@ class NewsletterListener implements EventSubscriberInterface
             "IsUnsubscribed" => "True",
         ];
 
-        list ($status, $data) = $this->api->put(MailjetClient::RESOURCE_LIST_RECIPIENT, $model->getRelationId(), $params);
+        list ($status, $data) = $this->api->delete(MailjetClient::RESOURCE_LIST_RECIPIENT, $model->getRelationId(), $params);
 
         $this->logAfterAction(
             sprintf("The email address '%s' has been correctly unsubscribed from the list", $event->getEmail()),


### PR DESCRIPTION
Apparemment api->put ne fonctionne pas très bien. 
Quand on veut se désincrire depuis la modification de compte en décochant la case ça ne fonctionnais pas. D'ailleurs quand on coche la case ça ne fonctionne pas. 
Du coup ligne 125 chez moi j'ai mis  if (1) {
mais je suppose que l'on peut faire autrement pour que ça fonctionne.
