### PR TITLE
Debug

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,12 +13,12 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.2</version>
+    <version>1.3</version>
     <author>
         <name>Benjamin Perche, Franck Allimant</name>
         <email>bperche@openstudio.fr, thelia@cqfdev.fr</email>
     </author>
     <type>classic</type>
-    <thelia>2.2.1</thelia>
+    <thelia>2.3.4</thelia>
     <stability>other</stability>
 </module>

--- a/Config/schema.xml
+++ b/Config/schema.xml
@@ -4,7 +4,7 @@
         <column name="id" autoIncrement="true" type="INTEGER" required="true" primaryKey="true" />
         <column name="mailjet_id" type="VARCHAR" size="255" required="true" />
         <column name="email" type="VARCHAR" size="255" required="true" />
-        <column name="relation_id" type="INTEGER" required="true" />
+        <column name="relation_id" type="INTEGER"/>
 
         <index name="idx_mailjet_newsletter_email">
             <index-column name="email" />
@@ -15,6 +15,9 @@
 
         <unique name="email_UNIQUE">
             <unique-column name="email" />
+        </unique>
+        <unique name="relation_id_UNIQUE">
+            <unique-column name="relation_id" />
         </unique>
     </table>
 

--- a/Config/schema.xml
+++ b/Config/schema.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <database defaultIdMethod="native" name="thelia">
     <table name="mailjet_newsletter" namespace="Mailjet\Model">
-        <column name="id" type="INTEGER" required="true" primaryKey="true" />
+        <column name="id" autoIncrement="true" type="INTEGER" required="true" primaryKey="true" />
+        <column name="mailjet_id" type="VARCHAR" size="255" required="true" />
         <column name="email" type="VARCHAR" size="255" required="true" />
         <column name="relation_id" type="INTEGER" required="true" />
 
@@ -14,9 +15,6 @@
 
         <unique name="email_UNIQUE">
             <unique-column name="email" />
-        </unique>
-        <unique name="relation_id_UNIQUE">
-            <unique-column name="relation_id" />
         </unique>
     </table>
 

--- a/Config/sqldb.map
+++ b/Config/sqldb.map
@@ -1,0 +1,2 @@
+# Sqlfile -> Database map
+thelia.sql=thelia

--- a/Config/thelia.sql
+++ b/Config/thelia.sql
@@ -14,9 +14,10 @@ CREATE TABLE `mailjet_newsletter`
     `id` INTEGER NOT NULL AUTO_INCREMENT,
     `mailjet_id` VARCHAR(255) NOT NULL,
     `email` VARCHAR(255) NOT NULL,
-    `relation_id` INTEGER NOT NULL,
+    `relation_id` INTEGER,
     PRIMARY KEY (`id`),
     UNIQUE INDEX `email_UNIQUE` (`email`),
+    UNIQUE INDEX `relation_id_UNIQUE` (`relation_id`),
     INDEX `idx_mailjet_newsletter_email` (`email`),
     INDEX `idx_mailjet_newsletter_relation_id` (`relation_id`)
 ) ENGINE=InnoDB;

--- a/Config/thelia.sql
+++ b/Config/thelia.sql
@@ -7,14 +7,16 @@ SET FOREIGN_KEY_CHECKS = 0;
 -- mailjet_newsletter
 -- ---------------------------------------------------------------------
 
-CREATE TABLE IF NOT EXISTS `mailjet_newsletter`
+DROP TABLE IF EXISTS `mailjet_newsletter`;
+
+CREATE TABLE `mailjet_newsletter`
 (
-    `id` INTEGER NOT NULL,
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `mailjet_id` VARCHAR(255) NOT NULL,
     `email` VARCHAR(255) NOT NULL,
     `relation_id` INTEGER NOT NULL,
     PRIMARY KEY (`id`),
     UNIQUE INDEX `email_UNIQUE` (`email`),
-    UNIQUE INDEX `relation_id_UNIQUE` (`relation_id`),
     INDEX `idx_mailjet_newsletter_email` (`email`),
     INDEX `idx_mailjet_newsletter_relation_id` (`relation_id`)
 ) ENGINE=InnoDB;

--- a/Config/update/1.3.sql
+++ b/Config/update/1.3.sql
@@ -6,6 +6,8 @@ SET FOREIGN_KEY_CHECKS = 0;
 -- mailjet_newsletter
 -- ---------------------------------------------------------------------
 
+ALTER TABLE `mailjet_newsletter` MODIFY `relation_id` INT;
+
 ALTER TABLE `mailjet_newsletter` MODIFY `id` VARCHAR(255);
 
 ALTER TABLE `mailjet_newsletter` CHANGE `id` `mailjet_id` VARCHAR(255);
@@ -15,8 +17,6 @@ ALTER TABLE `mailjet_newsletter` ADD COLUMN `id` INT NOT NULL AUTO_INCREMENT UNI
 ALTER TABLE `mailjet_newsletter`
     DROP PRIMARY KEY,
     ADD PRIMARY KEY (`id`);
-
-DROP INDEX `relation_id_UNIQUE` ON `mailjet_newsletter`;
 
 # This restores the fkey checks, after having unset them earlier
 SET FOREIGN_KEY_CHECKS = 1;

--- a/Config/update/1.3.sql
+++ b/Config/update/1.3.sql
@@ -1,0 +1,22 @@
+# This is a fix for InnoDB in MySQL >= 4.1.x
+# It "suspends judgement" for fkey relationships until are tables are set.
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ---------------------------------------------------------------------
+-- mailjet_newsletter
+-- ---------------------------------------------------------------------
+
+ALTER TABLE `mailjet_newsletter` MODIFY `id` VARCHAR(255);
+
+ALTER TABLE `mailjet_newsletter` CHANGE `id` `mailjet_id` VARCHAR(255);
+
+ALTER TABLE `mailjet_newsletter` ADD COLUMN `id` INT NOT NULL AUTO_INCREMENT UNIQUE FIRST;
+
+ALTER TABLE `mailjet_newsletter`
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (`id`);
+
+DROP INDEX `relation_id_UNIQUE` ON `mailjet_newsletter`;
+
+# This restores the fkey checks, after having unset them earlier
+SET FOREIGN_KEY_CHECKS = 1;

--- a/EventListeners/NewsletterListener.php
+++ b/EventListeners/NewsletterListener.php
@@ -123,7 +123,7 @@ class NewsletterListener implements EventSubscriberInterface
             "IsUnsubscribed" => "False",
         ];
 
-        if ((int)($model->getRelationId()) == 0) {
+        if ((int)($model->getRelationId()) === null) {
             $params["ContactID"] = $model->getMailjetId();
             $params["ListALT"]   = ConfigQuery::read(MailjetModule::CONFIG_NEWSLETTER_LIST);
 

--- a/EventListeners/NewsletterListener.php
+++ b/EventListeners/NewsletterListener.php
@@ -85,7 +85,7 @@ class NewsletterListener implements EventSubscriberInterface
                 ) {
                     // Reset relation ID.
                     $model
-                        ->setRelationId(0)
+                        ->setRelationId(null)
                         ->save();
                     /**
                      * Then create a new client

--- a/EventListeners/NewsletterListener.php
+++ b/EventListeners/NewsletterListener.php
@@ -65,7 +65,7 @@ class NewsletterListener implements EventSubscriberInterface
 
     public function update(NewsletterEvent $event)
     {
-        $previousEmail = NewsletterQuery::create()->findPk($event->getId())->getEmail();
+        $previousEmail = NewsletterQuery::create()->findPk($event->getMailjetId())->getEmail();
 
         if ($event->getEmail() !== $previousEmail) {
             if (null !== $model = MailjetNewsletterQuery::create()->findOneByEmail($previousEmail)) {
@@ -123,8 +123,8 @@ class NewsletterListener implements EventSubscriberInterface
             "IsUnsubscribed" => "False",
         ];
 
-        if (int($model->getRelationId()) == 0) {
-            $params["ContactID"] = $model->getId();
+        if ((int)($model->getRelationId()) == 0) {
+            $params["ContactID"] = $model->getMailjetId();
             $params["ListALT"]   = ConfigQuery::read(MailjetModule::CONFIG_NEWSLETTER_LIST);
 
             // Add the contact to the contact list
@@ -189,7 +189,7 @@ class NewsletterListener implements EventSubscriberInterface
 
                 $model = new MailjetNewsletter();
                 $model
-                    ->setId($data["Data"][0]["ID"])
+                    ->setMailjetId($data["Data"][0]["ID"])
                     ->setEmail($event->getEmail())
                     ->save();
             }
@@ -228,7 +228,7 @@ class NewsletterListener implements EventSubscriberInterface
 
     protected function getEmailFromEvent(NewsletterEvent $event)
     {
-        return NewsletterQuery::create()->findPk($event->getId())->getEmail();
+        return NewsletterQuery::create()->findPk($event->getMailjetId())->getEmail();
     }
 
     /**

--- a/EventListeners/NewsletterListener.php
+++ b/EventListeners/NewsletterListener.php
@@ -123,7 +123,7 @@ class NewsletterListener implements EventSubscriberInterface
             "IsUnsubscribed" => "False",
         ];
 
-        if ((int)($model->getRelationId()) === null) {
+        if (($model->getRelationId()) === null) {
             $params["ContactID"] = $model->getMailjetId();
             $params["ListALT"]   = ConfigQuery::read(MailjetModule::CONFIG_NEWSLETTER_LIST);
 

--- a/EventListeners/NewsletterListener.php
+++ b/EventListeners/NewsletterListener.php
@@ -65,7 +65,7 @@ class NewsletterListener implements EventSubscriberInterface
 
     public function update(NewsletterEvent $event)
     {
-        $previousEmail = NewsletterQuery::create()->findPk($event->getMailjetId())->getEmail();
+        $previousEmail = NewsletterQuery::create()->findPk($event->getId())->getEmail();
 
         if ($event->getEmail() !== $previousEmail) {
             if (null !== $model = MailjetNewsletterQuery::create()->findOneByEmail($previousEmail)) {
@@ -228,7 +228,7 @@ class NewsletterListener implements EventSubscriberInterface
 
     protected function getEmailFromEvent(NewsletterEvent $event)
     {
-        return NewsletterQuery::create()->findPk($event->getMailjetId())->getEmail();
+        return NewsletterQuery::create()->findPk($event->getId())->getEmail();
     }
 
     /**

--- a/EventListeners/NewsletterListener.php
+++ b/EventListeners/NewsletterListener.php
@@ -123,7 +123,7 @@ class NewsletterListener implements EventSubscriberInterface
             "IsUnsubscribed" => "False",
         ];
 
-        if (intval($model->getRelationId()) == 0) {
+        if (int($model->getRelationId()) == 0) {
             $params["ContactID"] = $model->getId();
             $params["ListALT"]   = ConfigQuery::read(MailjetModule::CONFIG_NEWSLETTER_LIST);
 

--- a/Model/Base/MailjetNewsletter.php
+++ b/Model/Base/MailjetNewsletter.php
@@ -58,6 +58,12 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
     protected $id;
 
     /**
+     * The value for the mailjet_id field.
+     * @var        string
+     */
+    protected $mailjet_id;
+
+    /**
      * The value for the email field.
      * @var        string
      */
@@ -347,6 +353,17 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
     }
 
     /**
+     * Get the [mailjet_id] column value.
+     *
+     * @return   string
+     */
+    public function getMailjetId()
+    {
+
+        return $this->mailjet_id;
+    }
+
+    /**
      * Get the [email] column value.
      *
      * @return   string
@@ -388,6 +405,27 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
 
         return $this;
     } // setId()
+
+    /**
+     * Set the value of [mailjet_id] column.
+     *
+     * @param      string $v new value
+     * @return   \Mailjet\Model\MailjetNewsletter The current object (for fluent API support)
+     */
+    public function setMailjetId($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->mailjet_id !== $v) {
+            $this->mailjet_id = $v;
+            $this->modifiedColumns[MailjetNewsletterTableMap::MAILJET_ID] = true;
+        }
+
+
+        return $this;
+    } // setMailjetId()
 
     /**
      * Set the value of [email] column.
@@ -471,10 +509,13 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
             $col = $row[TableMap::TYPE_NUM == $indexType ? 0 + $startcol : MailjetNewsletterTableMap::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)];
             $this->id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 1 + $startcol : MailjetNewsletterTableMap::translateFieldName('Email', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 1 + $startcol : MailjetNewsletterTableMap::translateFieldName('MailjetId', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->mailjet_id = (null !== $col) ? (string) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 2 + $startcol : MailjetNewsletterTableMap::translateFieldName('Email', TableMap::TYPE_PHPNAME, $indexType)];
             $this->email = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 2 + $startcol : MailjetNewsletterTableMap::translateFieldName('RelationId', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 3 + $startcol : MailjetNewsletterTableMap::translateFieldName('RelationId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->relation_id = (null !== $col) ? (int) $col : null;
             $this->resetModified();
 
@@ -484,7 +525,7 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 3; // 3 = MailjetNewsletterTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 4; // 4 = MailjetNewsletterTableMap::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception $e) {
             throw new PropelException("Error populating \Mailjet\Model\MailjetNewsletter object", 0, $e);
@@ -687,10 +728,17 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
         $modifiedColumns = array();
         $index = 0;
 
+        $this->modifiedColumns[MailjetNewsletterTableMap::ID] = true;
+        if (null !== $this->id) {
+            throw new PropelException('Cannot insert a value for auto-increment primary key (' . MailjetNewsletterTableMap::ID . ')');
+        }
 
          // check the columns in natural order for more readable SQL queries
         if ($this->isColumnModified(MailjetNewsletterTableMap::ID)) {
             $modifiedColumns[':p' . $index++]  = 'ID';
+        }
+        if ($this->isColumnModified(MailjetNewsletterTableMap::MAILJET_ID)) {
+            $modifiedColumns[':p' . $index++]  = 'MAILJET_ID';
         }
         if ($this->isColumnModified(MailjetNewsletterTableMap::EMAIL)) {
             $modifiedColumns[':p' . $index++]  = 'EMAIL';
@@ -712,6 +760,9 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
                     case 'ID':
                         $stmt->bindValue($identifier, $this->id, PDO::PARAM_INT);
                         break;
+                    case 'MAILJET_ID':
+                        $stmt->bindValue($identifier, $this->mailjet_id, PDO::PARAM_STR);
+                        break;
                     case 'EMAIL':
                         $stmt->bindValue($identifier, $this->email, PDO::PARAM_STR);
                         break;
@@ -725,6 +776,13 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
             Propel::log($e->getMessage(), Propel::LOG_ERR);
             throw new PropelException(sprintf('Unable to execute INSERT statement [%s]', $sql), 0, $e);
         }
+
+        try {
+            $pk = $con->lastInsertId();
+        } catch (Exception $e) {
+            throw new PropelException('Unable to get autoincrement id.', 0, $e);
+        }
+        $this->setId($pk);
 
         $this->setNew(false);
     }
@@ -777,9 +835,12 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
                 return $this->getId();
                 break;
             case 1:
-                return $this->getEmail();
+                return $this->getMailjetId();
                 break;
             case 2:
+                return $this->getEmail();
+                break;
+            case 3:
                 return $this->getRelationId();
                 break;
             default:
@@ -811,8 +872,9 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
         $keys = MailjetNewsletterTableMap::getFieldNames($keyType);
         $result = array(
             $keys[0] => $this->getId(),
-            $keys[1] => $this->getEmail(),
-            $keys[2] => $this->getRelationId(),
+            $keys[1] => $this->getMailjetId(),
+            $keys[2] => $this->getEmail(),
+            $keys[3] => $this->getRelationId(),
         );
         $virtualColumns = $this->virtualColumns;
         foreach ($virtualColumns as $key => $virtualColumn) {
@@ -856,9 +918,12 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
                 $this->setId($value);
                 break;
             case 1:
-                $this->setEmail($value);
+                $this->setMailjetId($value);
                 break;
             case 2:
+                $this->setEmail($value);
+                break;
+            case 3:
                 $this->setRelationId($value);
                 break;
         } // switch()
@@ -886,8 +951,9 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
         $keys = MailjetNewsletterTableMap::getFieldNames($keyType);
 
         if (array_key_exists($keys[0], $arr)) $this->setId($arr[$keys[0]]);
-        if (array_key_exists($keys[1], $arr)) $this->setEmail($arr[$keys[1]]);
-        if (array_key_exists($keys[2], $arr)) $this->setRelationId($arr[$keys[2]]);
+        if (array_key_exists($keys[1], $arr)) $this->setMailjetId($arr[$keys[1]]);
+        if (array_key_exists($keys[2], $arr)) $this->setEmail($arr[$keys[2]]);
+        if (array_key_exists($keys[3], $arr)) $this->setRelationId($arr[$keys[3]]);
     }
 
     /**
@@ -900,6 +966,7 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
         $criteria = new Criteria(MailjetNewsletterTableMap::DATABASE_NAME);
 
         if ($this->isColumnModified(MailjetNewsletterTableMap::ID)) $criteria->add(MailjetNewsletterTableMap::ID, $this->id);
+        if ($this->isColumnModified(MailjetNewsletterTableMap::MAILJET_ID)) $criteria->add(MailjetNewsletterTableMap::MAILJET_ID, $this->mailjet_id);
         if ($this->isColumnModified(MailjetNewsletterTableMap::EMAIL)) $criteria->add(MailjetNewsletterTableMap::EMAIL, $this->email);
         if ($this->isColumnModified(MailjetNewsletterTableMap::RELATION_ID)) $criteria->add(MailjetNewsletterTableMap::RELATION_ID, $this->relation_id);
 
@@ -965,11 +1032,12 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
      */
     public function copyInto($copyObj, $deepCopy = false, $makeNew = true)
     {
-        $copyObj->setId($this->getId());
+        $copyObj->setMailjetId($this->getMailjetId());
         $copyObj->setEmail($this->getEmail());
         $copyObj->setRelationId($this->getRelationId());
         if ($makeNew) {
             $copyObj->setNew(true);
+            $copyObj->setId(NULL); // this is a auto-increment column, so set to default value
         }
     }
 
@@ -1001,6 +1069,7 @@ abstract class MailjetNewsletter implements ActiveRecordInterface
     public function clear()
     {
         $this->id = null;
+        $this->mailjet_id = null;
         $this->email = null;
         $this->relation_id = null;
         $this->alreadyInSave = false;

--- a/Model/Base/MailjetNewsletterQuery.php
+++ b/Model/Base/MailjetNewsletterQuery.php
@@ -19,10 +19,12 @@ use Propel\Runtime\Exception\PropelException;
  *
  *
  * @method     ChildMailjetNewsletterQuery orderById($order = Criteria::ASC) Order by the id column
+ * @method     ChildMailjetNewsletterQuery orderByMailjetId($order = Criteria::ASC) Order by the mailjet_id column
  * @method     ChildMailjetNewsletterQuery orderByEmail($order = Criteria::ASC) Order by the email column
  * @method     ChildMailjetNewsletterQuery orderByRelationId($order = Criteria::ASC) Order by the relation_id column
  *
  * @method     ChildMailjetNewsletterQuery groupById() Group by the id column
+ * @method     ChildMailjetNewsletterQuery groupByMailjetId() Group by the mailjet_id column
  * @method     ChildMailjetNewsletterQuery groupByEmail() Group by the email column
  * @method     ChildMailjetNewsletterQuery groupByRelationId() Group by the relation_id column
  *
@@ -34,10 +36,12 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildMailjetNewsletter findOneOrCreate(ConnectionInterface $con = null) Return the first ChildMailjetNewsletter matching the query, or a new ChildMailjetNewsletter object populated from the query conditions when no match is found
  *
  * @method     ChildMailjetNewsletter findOneById(int $id) Return the first ChildMailjetNewsletter filtered by the id column
+ * @method     ChildMailjetNewsletter findOneByMailjetId(string $mailjet_id) Return the first ChildMailjetNewsletter filtered by the mailjet_id column
  * @method     ChildMailjetNewsletter findOneByEmail(string $email) Return the first ChildMailjetNewsletter filtered by the email column
  * @method     ChildMailjetNewsletter findOneByRelationId(int $relation_id) Return the first ChildMailjetNewsletter filtered by the relation_id column
  *
  * @method     array findById(int $id) Return ChildMailjetNewsletter objects filtered by the id column
+ * @method     array findByMailjetId(string $mailjet_id) Return ChildMailjetNewsletter objects filtered by the mailjet_id column
  * @method     array findByEmail(string $email) Return ChildMailjetNewsletter objects filtered by the email column
  * @method     array findByRelationId(int $relation_id) Return ChildMailjetNewsletter objects filtered by the relation_id column
  *
@@ -128,7 +132,7 @@ abstract class MailjetNewsletterQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT ID, EMAIL, RELATION_ID FROM mailjet_newsletter WHERE ID = :p0';
+        $sql = 'SELECT ID, MAILJET_ID, EMAIL, RELATION_ID FROM mailjet_newsletter WHERE ID = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -256,6 +260,35 @@ abstract class MailjetNewsletterQuery extends ModelCriteria
         }
 
         return $this->addUsingAlias(MailjetNewsletterTableMap::ID, $id, $comparison);
+    }
+
+    /**
+     * Filter the query on the mailjet_id column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByMailjetId('fooValue');   // WHERE mailjet_id = 'fooValue'
+     * $query->filterByMailjetId('%fooValue%'); // WHERE mailjet_id LIKE '%fooValue%'
+     * </code>
+     *
+     * @param     string $mailjetId The value to use as filter.
+     *              Accepts wildcards (* and % trigger a LIKE)
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildMailjetNewsletterQuery The current query, for fluid interface
+     */
+    public function filterByMailjetId($mailjetId = null, $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($mailjetId)) {
+                $comparison = Criteria::IN;
+            } elseif (preg_match('/[\%\*]/', $mailjetId)) {
+                $mailjetId = str_replace('*', '%', $mailjetId);
+                $comparison = Criteria::LIKE;
+            }
+        }
+
+        return $this->addUsingAlias(MailjetNewsletterTableMap::MAILJET_ID, $mailjetId, $comparison);
     }
 
     /**

--- a/Model/Map/MailjetNewsletterTableMap.php
+++ b/Model/Map/MailjetNewsletterTableMap.php
@@ -58,7 +58,7 @@ class MailjetNewsletterTableMap extends TableMap
     /**
      * The total number of columns
      */
-    const NUM_COLUMNS = 3;
+    const NUM_COLUMNS = 4;
 
     /**
      * The number of lazy-loaded columns
@@ -68,12 +68,17 @@ class MailjetNewsletterTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    const NUM_HYDRATE_COLUMNS = 3;
+    const NUM_HYDRATE_COLUMNS = 4;
 
     /**
      * the column name for the ID field
      */
     const ID = 'mailjet_newsletter.ID';
+
+    /**
+     * the column name for the MAILJET_ID field
+     */
+    const MAILJET_ID = 'mailjet_newsletter.MAILJET_ID';
 
     /**
      * the column name for the EMAIL field
@@ -97,12 +102,12 @@ class MailjetNewsletterTableMap extends TableMap
      * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
      */
     protected static $fieldNames = array (
-        self::TYPE_PHPNAME       => array('Id', 'Email', 'RelationId', ),
-        self::TYPE_STUDLYPHPNAME => array('id', 'email', 'relationId', ),
-        self::TYPE_COLNAME       => array(MailjetNewsletterTableMap::ID, MailjetNewsletterTableMap::EMAIL, MailjetNewsletterTableMap::RELATION_ID, ),
-        self::TYPE_RAW_COLNAME   => array('ID', 'EMAIL', 'RELATION_ID', ),
-        self::TYPE_FIELDNAME     => array('id', 'email', 'relation_id', ),
-        self::TYPE_NUM           => array(0, 1, 2, )
+        self::TYPE_PHPNAME       => array('Id', 'MailjetId', 'Email', 'RelationId', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'mailjetId', 'email', 'relationId', ),
+        self::TYPE_COLNAME       => array(MailjetNewsletterTableMap::ID, MailjetNewsletterTableMap::MAILJET_ID, MailjetNewsletterTableMap::EMAIL, MailjetNewsletterTableMap::RELATION_ID, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'MAILJET_ID', 'EMAIL', 'RELATION_ID', ),
+        self::TYPE_FIELDNAME     => array('id', 'mailjet_id', 'email', 'relation_id', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, )
     );
 
     /**
@@ -112,12 +117,12 @@ class MailjetNewsletterTableMap extends TableMap
      * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
      */
     protected static $fieldKeys = array (
-        self::TYPE_PHPNAME       => array('Id' => 0, 'Email' => 1, 'RelationId' => 2, ),
-        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'email' => 1, 'relationId' => 2, ),
-        self::TYPE_COLNAME       => array(MailjetNewsletterTableMap::ID => 0, MailjetNewsletterTableMap::EMAIL => 1, MailjetNewsletterTableMap::RELATION_ID => 2, ),
-        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'EMAIL' => 1, 'RELATION_ID' => 2, ),
-        self::TYPE_FIELDNAME     => array('id' => 0, 'email' => 1, 'relation_id' => 2, ),
-        self::TYPE_NUM           => array(0, 1, 2, )
+        self::TYPE_PHPNAME       => array('Id' => 0, 'MailjetId' => 1, 'Email' => 2, 'RelationId' => 3, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'mailjetId' => 1, 'email' => 2, 'relationId' => 3, ),
+        self::TYPE_COLNAME       => array(MailjetNewsletterTableMap::ID => 0, MailjetNewsletterTableMap::MAILJET_ID => 1, MailjetNewsletterTableMap::EMAIL => 2, MailjetNewsletterTableMap::RELATION_ID => 3, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'MAILJET_ID' => 1, 'EMAIL' => 2, 'RELATION_ID' => 3, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'mailjet_id' => 1, 'email' => 2, 'relation_id' => 3, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, )
     );
 
     /**
@@ -134,9 +139,10 @@ class MailjetNewsletterTableMap extends TableMap
         $this->setPhpName('MailjetNewsletter');
         $this->setClassName('\\Mailjet\\Model\\MailjetNewsletter');
         $this->setPackage('Mailjet.Model');
-        $this->setUseIdGenerator(false);
+        $this->setUseIdGenerator(true);
         // columns
         $this->addPrimaryKey('ID', 'Id', 'INTEGER', true, null, null);
+        $this->addColumn('MAILJET_ID', 'MailjetId', 'VARCHAR', true, 255, null);
         $this->addColumn('EMAIL', 'Email', 'VARCHAR', true, 255, null);
         $this->addColumn('RELATION_ID', 'RelationId', 'INTEGER', true, null, null);
     } // initialize()
@@ -287,10 +293,12 @@ class MailjetNewsletterTableMap extends TableMap
     {
         if (null === $alias) {
             $criteria->addSelectColumn(MailjetNewsletterTableMap::ID);
+            $criteria->addSelectColumn(MailjetNewsletterTableMap::MAILJET_ID);
             $criteria->addSelectColumn(MailjetNewsletterTableMap::EMAIL);
             $criteria->addSelectColumn(MailjetNewsletterTableMap::RELATION_ID);
         } else {
             $criteria->addSelectColumn($alias . '.ID');
+            $criteria->addSelectColumn($alias . '.MAILJET_ID');
             $criteria->addSelectColumn($alias . '.EMAIL');
             $criteria->addSelectColumn($alias . '.RELATION_ID');
         }
@@ -388,6 +396,10 @@ class MailjetNewsletterTableMap extends TableMap
             $criteria = clone $criteria; // rename for clarity
         } else {
             $criteria = $criteria->buildCriteria(); // build Criteria from MailjetNewsletter object
+        }
+
+        if ($criteria->containsKey(MailjetNewsletterTableMap::ID) && $criteria->keyContainsValue(MailjetNewsletterTableMap::ID) ) {
+            throw new PropelException('Cannot insert a value for auto-increment primary key ('.MailjetNewsletterTableMap::ID.')');
         }
 
 

--- a/Model/Map/MailjetNewsletterTableMap.php
+++ b/Model/Map/MailjetNewsletterTableMap.php
@@ -144,7 +144,7 @@ class MailjetNewsletterTableMap extends TableMap
         $this->addPrimaryKey('ID', 'Id', 'INTEGER', true, null, null);
         $this->addColumn('MAILJET_ID', 'MailjetId', 'VARCHAR', true, 255, null);
         $this->addColumn('EMAIL', 'Email', 'VARCHAR', true, 255, null);
-        $this->addColumn('RELATION_ID', 'RelationId', 'INTEGER', true, null, null);
+        $this->addColumn('RELATION_ID', 'RelationId', 'INTEGER', false, null, null);
     } // initialize()
 
     /**


### PR DESCRIPTION
 - relation_id is no longer required, so it wont be set to 0 which wont make it malfunction with the unique restraint in case of fail
 - id is now mailjet_id and changed from int to varchar(255), since int was too short for what mailjet gave us
 - new id column, auto incremented to serve as index