### PR TITLE
fix(newsletter): store Mailjet contact id in mailjet_id on subscribe

### DIFF
--- a/EventListeners/NewsletterListener.php
+++ b/EventListeners/NewsletterListener.php
@@ -202,7 +202,7 @@ class NewsletterListener implements EventSubscriberInterface
 
                 $model = new MailjetNewsletter();
                 $model
-                    ->setRelationId($data["Data"][0]["ID"])
+                    ->setMailjetId($data["Data"][0]["ID"])
                     ->setEmail($event->getEmail())
                     ->save();
             }


### PR DESCRIPTION
apiAddUser() created the MailjetNewsletter with the Mailjet contact id set on relation_id, leaving the required mailjet_id column null. This broke the INSERT (mailjet_id is NOT NULL) and prevented apiAddContactList() from adding the contact to the list. Store the contact id in mailjet_id so the record can be persisted and the relation_id is later set with the real list-recipient id.